### PR TITLE
fix: rename IMAGE_VERSION to OUTPUT_IMAGE_VERSION and improve README

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -2,10 +2,10 @@
 # Variables (can be overridden via environment or CLI)
 # ============================================================
 ISTIO_CODE_VERSION ?= 1.24.0
-IMAGE_VERSION      ?= 1.24.0-custom-v1
+OUTPUT_IMAGE_VERSION      ?= 1.24.0-custom-v1
 ISTIO_REPO         ?= https://github.com/istio/istio.git
 BUILD_DIR          ?= /tmp/build
-DOCKER_IMAGE       ?= istioctl-debug:$(IMAGE_VERSION)
+DOCKER_IMAGE       ?= istioctl-debug:$(OUTPUT_IMAGE_VERSION)
 RUN_AS_USER        ?=
 OWNER              ?=
 
@@ -14,12 +14,12 @@ OWNER              ?=
 # ============================================================
 # Version Check
 # ============================================================
-IMAGE_BASE_VERSION := $(word 1,$(subst -, ,$(IMAGE_VERSION)))
+IMAGE_BASE_VERSION := $(word 1,$(subst -, ,$(OUTPUT_IMAGE_VERSION)))
 
 ifeq ($(ISTIO_CODE_VERSION),$(IMAGE_BASE_VERSION))
   # OK
 else
-  $(error ❌ Version mismatch: ISTIO_CODE_VERSION ($(ISTIO_CODE_VERSION)) != IMAGE_VERSION base ($(IMAGE_BASE_VERSION)))
+  $(error ❌ Version mismatch: ISTIO_CODE_VERSION ($(ISTIO_CODE_VERSION)) != OUTPUT_IMAGE_VERSION base ($(IMAGE_BASE_VERSION)))
 endif
 
 PATCH_ROOT_GO := patches/root.go
@@ -53,7 +53,7 @@ help:
 	@echo "  make version          Show built image and cleanup binary"
 	@echo "  make clean            Remove build artifacts"
 	@echo ""
-	@echo "Variables you can override: ISTIO_CODE_VERSION, IMAGE_VERSION, BUILD_DIR, DOCKER_IMAGE, RUN_AS_USER, OWNER"
+	@echo "Variables you can override: ISTIO_CODE_VERSION, OUTPUT_IMAGE_VERSION, BUILD_DIR, DOCKER_IMAGE, RUN_AS_USER, OWNER"
 
 # ============================================================
 # Pre-checks

--- a/README.md
+++ b/README.md
@@ -49,7 +49,7 @@ Targets Overview (Quick Reference)
 
 | Target / Command    | Description                                                                                       |
 | ------------------- | ------------------------------------------------------------------------------------------------- |
-| **Version Check**   | Ensures `ISTIO_CODE_VERSION` matches the base version of `IMAGE_VERSION`; otherwise, build stops. |
+| **Version Check**   | Ensures `ISTIO_CODE_VERSION` matches the base version of `OUTPUT_IMAGE_VERSION`; otherwise, build stops. |
 | `make` / `make all` | Default: runs `image` (build Docker image) + `version` (print info & cleanup).                    |
 | `make clone`        | Clone or update the Istio repo at `$(BUILD_DIR)` and checkout `ISTIO_CODE_VERSION`.               |
 | `make patch`        | Apply local patches (copy `debugtool` sources and replace `root.go`).                             |
@@ -127,7 +127,7 @@ istioctl debugtool
 # Quick Reference
 ```bash
 # Load image into another Kind cluster
-kind load docker-image istioctl-debug:<IMAGE_VERSION> --name <kind-cluster>
+kind load docker-image istioctl-debug:<OUTPUT_IMAGE_VERSION> --name <kind-cluster>
 
 # Run debugtool against a pod
 istioctl debugtool default <pod>
@@ -138,7 +138,7 @@ git restore .
 ```
 
 # Tips
-- Always ensure `ISTIO_CODE_VERSION` and `IMAGE_VERSION` are aligned (the Makefile enforces this).
+- Always ensure `ISTIO_CODE_VERSION` and `OUTPUT_IMAGE_VERSION` are aligned (the Makefile enforces this).
 - Use `make help` to see available targets and quick usage hints.
 - For internal builds (`make mylab`), remember to set `OWNER=<your-org>`.
 - `GITHUB_TOKEN` is required for `/github-flow` with Contents / Issues / Pull requests read & write permissions.

--- a/README.md
+++ b/README.md
@@ -141,6 +141,12 @@ istioctl debugtool
 # Load image into another Kind cluster
 kind load docker-image istioctl-debug:<OUTPUT_IMAGE_VERSION> --name <kind-cluster>
 
+# Check built images
+docker images | grep istioctl-debug
+
+# Remove old image
+docker rmi istioctl-debug:<OUTPUT_IMAGE_VERSION>
+
 # Run debugtool against a pod
 istioctl debugtool default <pod>
 istioctl debugtool default <pod> -o /tmp/debug-info
@@ -150,7 +156,9 @@ git restore .
 ```
 
 # Tips
-- Always ensure `ISTIO_CODE_VERSION` and `OUTPUT_IMAGE_VERSION` are aligned (the Makefile enforces this).
+- Always ensure `ISTIO_CODE_VERSION` and `OUTPUT_IMAGE_VERSION` are aligned (the Makefile enforces this). `OUTPUT_IMAGE_VERSION` format must be `{version}-{label}`, e.g. `1.24.0-custom-v1`.
 - Use `make help` to see available targets and quick usage hints.
 - For internal builds (`make mylab`), remember to set `OWNER=<your-org>`.
+- For non-root builds, use `make switch-user RUN_AS_USER=<username>`.
+- If build fails with `permission denied on /gocache`, run: `docker volume rm gocache`.
 - `GITHUB_TOKEN` is required for `/github-flow` with Contents / Issues / Pull requests read & write permissions.

--- a/README.md
+++ b/README.md
@@ -72,6 +72,9 @@ Below is an example workflow to build the custom `istioctl` image, load it into 
 make                 # Build docker image (default)
 make all             # Same as 'make'
 make mylab OWNER=me  # Internal mylab build
+
+# Build a specific version
+make ISTIO_CODE_VERSION=1.13.5 OUTPUT_IMAGE_VERSION=1.13.5-custom-v1
 ```
 
 ## 2. Load the image into Kind

--- a/README.md
+++ b/README.md
@@ -79,17 +79,24 @@ make ISTIO_CODE_VERSION=1.13.5 OUTPUT_IMAGE_VERSION=1.13.5-custom-v1
 
 ## 2. Load the image into Kind
 ```bash
-kind load docker-image istioctl-debug:1.24.0-custom-v1 --name hub
+kind load docker-image istioctl-debug:<OUTPUT_IMAGE_VERSION> --name hub
 ```
 
 ## 3. Deploy the debug pod to Kubernetes
 ```bash
 kubectl apply -f manifests/clusterrole-istioctl-debug-limited-readonly.yml
 kubectl apply -f manifests/deploy.yaml
+
+# 確認 pod 已 Ready
+kubectl rollout status deploy/istioctl-debug -n default
 ```
 
 ## 4. Run istioctl debugtool inside the pod
 ```bash
+# 確認 binary 版本與 debugtool 是否正確載入
+kubectl exec -it deploy/istioctl-debug -n default -- istioctl version
+kubectl exec -it deploy/istioctl-debug -n default -- istioctl --help | grep debugtool
+
 # Exec into the pod
 kubectl exec -it deploy/istioctl-debug -n default -- \
   istioctl debugtool default <pod>
@@ -101,7 +108,9 @@ kubectl exec -it deploy/istioctl-debug -n default -- \
 
 ## 5. Run locally with Docker (no Kubernetes)
 ```bash
-docker run --rm -it --entrypoint /bin/sh istioctl-debug:1.24.0-custom-v1
+docker run --rm -it --entrypoint /bin/sh istioctl-debug:<OUTPUT_IMAGE_VERSION>
+istioctl version
+istioctl --help | grep debugtool
 istioctl debugtool
 ```
 


### PR DESCRIPTION
## 說明

### Makefile（Issue #49）
- 將 `IMAGE_VERSION` 改名為 `OUTPUT_IMAGE_VERSION`，避免與 istio 上游 Makefile 內部變數衝突
- 修正後 1.13.5 build 驗證通過

### README 補強
- Build image 範例加上版本切換指令與 `<OUTPUT_IMAGE_VERSION>` 佔位符
- Step 3 補上 `kubectl rollout status` 驗證
- Step 4 補上 `istioctl version` 與 `grep debugtool` 確認
- Step 5 本地測試補上版本驗證指令
- Quick Reference 補上 `docker images` 查詢與 `docker rmi` 清除指令
- Tips 補上 `OUTPUT_IMAGE_VERSION` 格式說明、`RUN_AS_USER` 提示、gocache 清除方式

Closes #49