### PR TITLE
chore: sync 1-feat-new changes to main

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -6,7 +6,7 @@ IMAGE_VERSION      ?= 1.24.0-custom-v1
 ISTIO_REPO         ?= https://github.com/istio/istio.git
 BUILD_DIR          ?= /tmp/build
 DOCKER_IMAGE       ?= istioctl-debug:$(IMAGE_VERSION)
-USER               ?=
+RUN_AS_USER        ?=
 OWNER              ?=
 
 .DEFAULT_GOAL := all
@@ -35,7 +35,7 @@ endif
 # ============================================================
 # Phony Targets
 # ============================================================
-.PHONY: help all check-root check-tmp clone patch build image \
+.PHONY: help all check-tmp clone patch build image \
         switch-user mylab version clean
 
 # ============================================================
@@ -43,25 +43,17 @@ endif
 # ============================================================
 help:
 	@echo "Makefile targets:"
-	@echo "  make all            Build docker image and show version"
-	@echo "  make clone          Clone/update Istio repo"
-	@echo "  make patch          Apply local patches"
-	@echo "  make build          Build istioctl binary"
-	@echo "  make image          Build docker image (default)"
-	@echo "  make switch-user    Re-run as another user (needs USER)"
-	@echo "  make mylab          Internal build via mylab_cli (needs OWNER)"
-	@echo "  make version        Show built image and cleanup binary"
-	@echo "  make clean          Remove build artifacts"
+	@echo "  make all              Build docker image and show version"
+	@echo "  make clone            Clone/update Istio repo"
+	@echo "  make patch            Apply local patches"
+	@echo "  make build            Build istioctl binary"
+	@echo "  make image            Build docker image (default)"
+	@echo "  make switch-user      Re-run as another user (needs RUN_AS_USER)"
+	@echo "  make mylab            Internal build via mylab_cli (needs OWNER)"
+	@echo "  make version          Show built image and cleanup binary"
+	@echo "  make clean            Remove build artifacts"
 	@echo ""
-	@echo "Variables you can override: ISTIO_CODE_VERSION, IMAGE_VERSION, BUILD_DIR, DOCKER_IMAGE, USER, OWNER"
-
-# ============================================================
-# Root Check (提示，而不是直接阻斷)
-# ============================================================
-check-root:
-	@if [ "$$(id -u)" -ne 0 ]; then \
-	  echo "⚠️  Warning: not running as root. Some commands may fail (e.g., docker)."; \
-	fi
+	@echo "Variables you can override: ISTIO_CODE_VERSION, IMAGE_VERSION, BUILD_DIR, DOCKER_IMAGE, RUN_AS_USER, OWNER"
 
 # ============================================================
 # Pre-checks
@@ -79,8 +71,8 @@ check-tmp:
 clone: check-tmp
 	@if [ -d $(BUILD_DIR)/istio/.git ]; then \
 	  echo "🔄 Updating Istio source at $(BUILD_DIR)/istio ..."; \
-          echo "    ↳ target version: $(ISTIO_CODE_VERSION)"; \
-          cd $(BUILD_DIR)/istio && \
+	  echo "    ↳ target version: $(ISTIO_CODE_VERSION)"; \
+	  cd $(BUILD_DIR)/istio && \
 	  git reset --hard HEAD && \
 	  git fetch --all && \
 	  echo "    ↳ switching to: $(ISTIO_CODE_VERSION)"; \
@@ -104,13 +96,13 @@ patch:
 	else \
 	  echo "ℹ️  No patches/debugtool found, skipping..."; \
 	fi
-	@if [ -f patches/root.go ]; then \
+	@if [ -f $(PATCH_ROOT_GO) ]; then \
 	  echo "📂 Replacing istioctl/cmd/root.go ..."; \
 	  echo "    ↳ source: $(PATCH_ROOT_GO)"; \
 	  echo "    ↳ target: $(BUILD_DIR)/istio/istioctl/cmd/root.go"; \
 	  cp $(PATCH_ROOT_GO) $(BUILD_DIR)/istio/istioctl/cmd/root.go; \
 	else \
-	  echo "ℹ️  No patches/root.go found, skipping..."; \
+	  echo "ℹ️  No $(PATCH_ROOT_GO) found, skipping..."; \
 	fi
 
 # ============================================================
@@ -128,22 +120,23 @@ build: clone patch
 # ============================================================
 all: image version
 
-image: build check-root
+image: build
 	@echo "🐳 Building docker image: $(DOCKER_IMAGE)"
 	docker build -t $(DOCKER_IMAGE) .
 
 switch-user:
-	@if [ -z "$(USER)" ]; then \
-	  echo "❌ USER not defined. Run with 'make switch-user USER=<username>'"; \
+	@if [ -z "$(RUN_AS_USER)" ]; then \
+	  echo "❌ RUN_AS_USER not defined. Run with 'make switch-user RUN_AS_USER=<username>'"; \
 	  exit 1; \
 	fi
-	sudo -u $(USER) bash -c "echo '🔄 Switching to user: $(USER)'; make mylab OWNER=$(USER)"
+	sudo -u $(RUN_AS_USER) bash -c "echo '🔄 Switching to user: $(RUN_AS_USER)'; make mylab OWNER=$(RUN_AS_USER)"
 
-mylab: build
+mylab:
 	@if [ -z "$(OWNER)" ]; then \
 	  echo "❌ OWNER not defined. Run with 'make mylab OWNER=<ownername>'"; \
 	  exit 1; \
 	fi
+	$(MAKE) build
 	@echo "🚀 Running internal build for $(OWNER)/$(DOCKER_IMAGE)"
 	/usr/local/mylab_cli/mylabbuild $(OWNER)/$(DOCKER_IMAGE)
 

--- a/Makefile
+++ b/Makefile
@@ -2,10 +2,10 @@
 # Variables (can be overridden via environment or CLI)
 # ============================================================
 ISTIO_CODE_VERSION ?= 1.24.0
-IMAGE_VERSION      ?= 1.24.0-custom-v1
+OUTPUT_IMAGE_VERSION      ?= 1.24.0-custom-v1
 ISTIO_REPO         ?= https://github.com/istio/istio.git
 BUILD_DIR          ?= /tmp/build
-DOCKER_IMAGE       ?= istioctl-debug:$(IMAGE_VERSION)
+DOCKER_IMAGE       ?= istioctl-debug:$(OUTPUT_IMAGE_VERSION)
 RUN_AS_USER        ?=
 OWNER              ?=
 
@@ -14,12 +14,12 @@ OWNER              ?=
 # ============================================================
 # Version Check
 # ============================================================
-IMAGE_BASE_VERSION := $(word 1,$(subst -, ,$(IMAGE_VERSION)))
+IMAGE_BASE_VERSION := $(word 1,$(subst -, ,$(OUTPUT_IMAGE_VERSION)))
 
 ifeq ($(ISTIO_CODE_VERSION),$(IMAGE_BASE_VERSION))
   # OK
 else
-  $(error ❌ Version mismatch: ISTIO_CODE_VERSION ($(ISTIO_CODE_VERSION)) != IMAGE_VERSION base ($(IMAGE_BASE_VERSION)))
+  $(error ❌ Version mismatch: ISTIO_CODE_VERSION ($(ISTIO_CODE_VERSION)) != OUTPUT_IMAGE_VERSION base ($(IMAGE_BASE_VERSION)))
 endif
 
 PATCH_ROOT_GO := patches/root.go
@@ -53,7 +53,7 @@ help:
 	@echo "  make version          Show built image and cleanup binary"
 	@echo "  make clean            Remove build artifacts"
 	@echo ""
-	@echo "Variables you can override: ISTIO_CODE_VERSION, IMAGE_VERSION, BUILD_DIR, DOCKER_IMAGE, RUN_AS_USER, OWNER"
+	@echo "Variables you can override: ISTIO_CODE_VERSION, OUTPUT_IMAGE_VERSION, BUILD_DIR, DOCKER_IMAGE, RUN_AS_USER, OWNER"
 
 # ============================================================
 # Pre-checks

--- a/README.md
+++ b/README.md
@@ -49,7 +49,7 @@ Targets Overview (Quick Reference)
 
 | Target / Command    | Description                                                                                       |
 | ------------------- | ------------------------------------------------------------------------------------------------- |
-| **Version Check**   | Ensures `ISTIO_CODE_VERSION` matches the base version of `IMAGE_VERSION`; otherwise, build stops. |
+| **Version Check**   | Ensures `ISTIO_CODE_VERSION` matches the base version of `OUTPUT_IMAGE_VERSION`; otherwise, build stops. |
 | `make` / `make all` | Default: runs `image` (build Docker image) + `version` (print info & cleanup).                    |
 | `make clone`        | Clone or update the Istio repo at `$(BUILD_DIR)` and checkout `ISTIO_CODE_VERSION`.               |
 | `make patch`        | Apply local patches (copy `debugtool` sources and replace `root.go`).                             |
@@ -127,7 +127,7 @@ istioctl debugtool
 # Quick Reference
 ```bash
 # Load image into another Kind cluster
-kind load docker-image istioctl-debug:<IMAGE_VERSION> --name <kind-cluster>
+kind load docker-image istioctl-debug:<OUTPUT_IMAGE_VERSION> --name <kind-cluster>
 
 # Run debugtool against a pod
 istioctl debugtool default <pod>
@@ -138,7 +138,7 @@ git restore .
 ```
 
 # Tips
-- Always ensure `ISTIO_CODE_VERSION` and `IMAGE_VERSION` are aligned (the Makefile enforces this).
+- Always ensure `ISTIO_CODE_VERSION` and `OUTPUT_IMAGE_VERSION` are aligned (the Makefile enforces this).
 - Use `make help` to see available targets and quick usage hints.
 - For internal builds (`make mylab`), remember to set `OWNER=<your-org>`.
 - `GITHUB_TOKEN` is required for `/github-flow` with Contents / Issues / Pull requests read & write permissions.

--- a/README.md
+++ b/README.md
@@ -55,7 +55,7 @@ Targets Overview (Quick Reference)
 | `make patch`        | Apply local patches (copy `debugtool` sources and replace `root.go`).                             |
 | `make build`        | Compile `istioctl` from source after cloning and applying patches.                                |
 | `make image`        | Build Docker image with the compiled binary.                                                      |
-| `make switch-user`  | Re-run the build as another Linux user (requires `USER=<username>`).                              |
+| `make switch-user`  | Re-run the build as another Linux user (requires `RUN_AS_USER=<username>`).                       |
 | `make mylab`        | Run a custom **mylab\_cli** build (requires `OWNER=<owner>`).                                     |
 | `make version`      | Print built image tag and cleanup temporary `bin/istioctl`.                                       |
 | `make clean`        | Remove build artifacts (`$(BUILD_DIR)` and `./bin`).                                              |

--- a/README.md
+++ b/README.md
@@ -141,6 +141,12 @@ istioctl debugtool
 # Load image into another Kind cluster
 kind load docker-image istioctl-debug:<OUTPUT_IMAGE_VERSION> --name <kind-cluster>
 
+# Check built images
+docker images | grep istioctl-debug
+
+# Remove old image
+docker rmi istioctl-debug:<OUTPUT_IMAGE_VERSION>
+
 # Run debugtool against a pod
 istioctl debugtool default <pod>
 istioctl debugtool default <pod> -o /tmp/debug-info
@@ -150,7 +156,9 @@ git restore .
 ```
 
 # Tips
-- Always ensure `ISTIO_CODE_VERSION` and `OUTPUT_IMAGE_VERSION` are aligned (the Makefile enforces this).
+- Always ensure `ISTIO_CODE_VERSION` and `OUTPUT_IMAGE_VERSION` are aligned (the Makefile enforces this). `OUTPUT_IMAGE_VERSION` format must be `{version}-{label}`, e.g. `1.24.0-custom-v1`.
 - Use `make help` to see available targets and quick usage hints.
 - For internal builds (`make mylab`), remember to set `OWNER=<your-org>`.
+- For non-root builds, use `make switch-user RUN_AS_USER=<username>`.
+- If build fails with `permission denied on /gocache`, run: `docker volume rm gocache`.
 - `GITHUB_TOKEN` is required for `/github-flow` with Contents / Issues / Pull requests read & write permissions.

--- a/README.md
+++ b/README.md
@@ -72,6 +72,9 @@ Below is an example workflow to build the custom `istioctl` image, load it into 
 make                 # Build docker image (default)
 make all             # Same as 'make'
 make mylab OWNER=me  # Internal mylab build
+
+# Build a specific version
+make ISTIO_CODE_VERSION=1.13.5 OUTPUT_IMAGE_VERSION=1.13.5-custom-v1
 ```
 
 ## 2. Load the image into Kind

--- a/README.md
+++ b/README.md
@@ -79,17 +79,24 @@ make ISTIO_CODE_VERSION=1.13.5 OUTPUT_IMAGE_VERSION=1.13.5-custom-v1
 
 ## 2. Load the image into Kind
 ```bash
-kind load docker-image istioctl-debug:1.24.0-custom-v1 --name hub
+kind load docker-image istioctl-debug:<OUTPUT_IMAGE_VERSION> --name hub
 ```
 
 ## 3. Deploy the debug pod to Kubernetes
 ```bash
 kubectl apply -f manifests/clusterrole-istioctl-debug-limited-readonly.yml
 kubectl apply -f manifests/deploy.yaml
+
+# 確認 pod 已 Ready
+kubectl rollout status deploy/istioctl-debug -n default
 ```
 
 ## 4. Run istioctl debugtool inside the pod
 ```bash
+# 確認 binary 版本與 debugtool 是否正確載入
+kubectl exec -it deploy/istioctl-debug -n default -- istioctl version
+kubectl exec -it deploy/istioctl-debug -n default -- istioctl --help | grep debugtool
+
 # Exec into the pod
 kubectl exec -it deploy/istioctl-debug -n default -- \
   istioctl debugtool default <pod>
@@ -101,7 +108,9 @@ kubectl exec -it deploy/istioctl-debug -n default -- \
 
 ## 5. Run locally with Docker (no Kubernetes)
 ```bash
-docker run --rm -it --entrypoint /bin/sh istioctl-debug:1.24.0-custom-v1
+docker run --rm -it --entrypoint /bin/sh istioctl-debug:<OUTPUT_IMAGE_VERSION>
+istioctl version
+istioctl --help | grep debugtool
 istioctl debugtool
 ```
 


### PR DESCRIPTION
將 `1-feat-new-branch-for-develop-and-test` 的變更合併回 `main`，包含：

- fix: improve Makefile correctness and usability（PR #48 / Issue #46、#47）
- fix: rename IMAGE_VERSION to OUTPUT_IMAGE_VERSION（PR #50 / Issue #49）

Closes #46
Closes #47
Closes #49