### PR TITLE
docs: align github-flow.md with kind-create-cluster issue title guidelines

### DIFF
--- a/.claude/commands/github-flow.md
+++ b/.claude/commands/github-flow.md
@@ -16,7 +16,7 @@
 
 ### Step 1：收集資訊
 詢問使用者：
-- **Issue 標題**（例如：`feat: add xxx`）
+- **Issue 標題**（例如：`feat: add xxx`，**標題一律使用英文**）
 - **Issue 描述**（問題背景、預計異動）
 - **Branch slug**（例如：`add-xxx`，會自動加上 issue 編號變成 `{number}-add-xxx`）
 - **目標 base branch**（預設 `1-feat-new-branch-for-develop-and-test`）— feature branch 從此 branch 切出，PR 也 merge 回此 branch
@@ -92,6 +92,13 @@ curl -s -X POST \
 ```
 
 > **原因**：GitHub 的 `Closes #X` 只在 PR merge 進 default branch（`main`）時觸發，feature branch → `1-feat-new` 不會自動關閉 issue。
+
+---
+
+## Issue 標題準則
+
+- **一律使用英文**撰寫 issue 標題
+- 格式：`<type>: <short description>`，例如 `feat: add xxx`、`fix: xxx not working`、`chore: update xxx`
 
 ---
 


### PR DESCRIPTION
## 異動內容

- Step 1 收集資訊的 Issue 標題項目加入「**標題一律使用英文**」說明
- 新增「Issue 標題準則」章節，包含格式規範（）與範例

## 參考

對齊  的 

Closes #61