### PR TITLE
feat: upgrade istioctl-debug default version to Istio 1.29.2

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,8 +1,8 @@
 # ============================================================
 # Variables (can be overridden via environment or CLI)
 # ============================================================
-ISTIO_CODE_VERSION ?= 1.24.0
-OUTPUT_IMAGE_VERSION      ?= 1.24.0-custom-v1
+ISTIO_CODE_VERSION ?= 1.29.2
+OUTPUT_IMAGE_VERSION      ?= 1.29.2-custom-v1
 ISTIO_REPO         ?= https://github.com/istio/istio.git
 BUILD_DIR          ?= /tmp/build
 DOCKER_IMAGE       ?= istioctl-debug:$(OUTPUT_IMAGE_VERSION)

--- a/manifests/deploy.yaml
+++ b/manifests/deploy.yaml
@@ -3,7 +3,7 @@
 apiVersion: apps/v1
 kind: Deployment
 metadata:
-  name: istioctl-debug-1-24-0
+  name: istioctl-debug-1-29-2
 spec:
   replicas: 1
   selector:
@@ -17,7 +17,7 @@ spec:
       serviceAccountName: istioctl-debug
       containers:
       - name: istioctl
-        image: istioctl-debug:1.24.0-custom-v1
+        image: istioctl-debug:1.29.2-custom-v1
         command: ["/bin/bash"]
         args: ["-c", "sleep infinity"]
 


### PR DESCRIPTION
## Summary

- Tested full Istio 1.29.2 build pipeline: clone → patch (debugtool) → compile → Docker image ✅
- `istioctl version`: reports `1.29-dev` ✅
- `istioctl debugtool`: command registered and visible in `--help` ✅
- Update Makefile default `ISTIO_CODE_VERSION` / `OUTPUT_IMAGE_VERSION` to 1.29.2
- Update `manifests/deploy.yaml` deployment name and image tag to 1.29.2-custom-v1

## Test plan

- [x] `make clone ISTIO_CODE_VERSION=1.29.2 OUTPUT_IMAGE_VERSION=1.29.2-custom-v1`
- [x] `make patch ISTIO_CODE_VERSION=1.29.2 OUTPUT_IMAGE_VERSION=1.29.2-custom-v1`
- [x] `make build ISTIO_CODE_VERSION=1.29.2 OUTPUT_IMAGE_VERSION=1.29.2-custom-v1`
- [x] `make image ISTIO_CODE_VERSION=1.29.2 OUTPUT_IMAGE_VERSION=1.29.2-custom-v1`
- [x] `docker run --rm istioctl-debug:1.29.2-custom-v1 -c "istioctl version --remote=false"` → `1.29-dev`
- [x] `docker run --rm istioctl-debug:1.29.2-custom-v1 -c "istioctl --help | grep debugtool"` → found

Closes #70

🤖 Generated with [Claude Code](https://claude.com/claude-code)