### PR TITLE
feat: add .gcloudignore and EXTRA_FILES_DIR support for mylab build

### DIFF
--- a/.gcloudignore
+++ b/.gcloudignore
@@ -1,0 +1,5 @@
+# Inherit .gitignore rules, then explicitly include the compiled binaries
+# and extra files needed by the Dockerfile's COPY steps.
+#!include:.gitignore
+!bin/istioctl
+!bin/extra/

--- a/.gitignore
+++ b/.gitignore
@@ -1,1 +1,2 @@
 bin/istioctl
+bin/extra/

--- a/Dockerfile
+++ b/Dockerfile
@@ -5,6 +5,7 @@ RUN apk add --no-cache bash curl ca-certificates
 
 WORKDIR /usr/local/bin
 COPY bin/istioctl .
+COPY bin/extra/ .
 RUN chmod +x istioctl
 
 # 預設進入 bash，方便互動

--- a/Makefile
+++ b/Makefile
@@ -8,6 +8,7 @@ BUILD_DIR          ?= /tmp/build
 DOCKER_IMAGE       ?= istioctl-debug:$(OUTPUT_IMAGE_VERSION)
 RUN_AS_USER        ?=
 OWNER              ?=
+EXTRA_FILES_DIR    ?=
 
 .DEFAULT_GOAL := all
 
@@ -53,7 +54,7 @@ help:
 	@echo "  make version          Show built image and cleanup binary"
 	@echo "  make clean            Remove build artifacts"
 	@echo ""
-	@echo "Variables you can override: ISTIO_CODE_VERSION, OUTPUT_IMAGE_VERSION, BUILD_DIR, DOCKER_IMAGE, RUN_AS_USER, OWNER"
+	@echo "Variables you can override: ISTIO_CODE_VERSION, OUTPUT_IMAGE_VERSION, BUILD_DIR, DOCKER_IMAGE, RUN_AS_USER, OWNER, EXTRA_FILES_DIR"
 
 # ============================================================
 # Pre-checks
@@ -122,6 +123,11 @@ all: image version
 
 image: build
 	@echo "🐳 Building docker image: $(DOCKER_IMAGE)"
+	mkdir -p bin/extra
+	@if [ -n "$(EXTRA_FILES_DIR)" ]; then \
+	  echo "📦 Staging extra files from: $(EXTRA_FILES_DIR)"; \
+	  cp -r $(EXTRA_FILES_DIR)/. bin/extra/; \
+	fi
 	docker build -t $(DOCKER_IMAGE) .
 
 switch-user:
@@ -145,8 +151,9 @@ mylab:
 # ============================================================
 version:
 	@echo "✅ Built image: $(DOCKER_IMAGE)"
-	@echo "🧹 Cleanup local bin/istioctl ..."
+	@echo "🧹 Cleanup local bin/ ..."
 	rm -f bin/istioctl
+	rm -rf bin/extra
 
 clean:
 	@echo "🧹 Cleaning up build dir and bin ..."

--- a/Makefile
+++ b/Makefile
@@ -125,8 +125,15 @@ image: build
 	@echo "🐳 Building docker image: $(DOCKER_IMAGE)"
 	mkdir -p bin/extra
 	@if [ -n "$(EXTRA_FILES_DIR)" ]; then \
-	  echo "📦 Staging extra files from: $(EXTRA_FILES_DIR)"; \
-	  cp -r $(EXTRA_FILES_DIR)/. bin/extra/; \
+	  if [ -f "$(EXTRA_FILES_DIR)" ]; then \
+	    echo "📦 Staging extra file: $(EXTRA_FILES_DIR)"; \
+	    cp "$(EXTRA_FILES_DIR)" bin/extra/; \
+	  elif [ -d "$(EXTRA_FILES_DIR)" ]; then \
+	    echo "📦 Staging extra files from dir: $(EXTRA_FILES_DIR)"; \
+	    cp -r "$(EXTRA_FILES_DIR)/." bin/extra/; \
+	  else \
+	    echo "❌ EXTRA_FILES_DIR not found: $(EXTRA_FILES_DIR)"; exit 1; \
+	  fi \
 	fi
 	docker build -t $(DOCKER_IMAGE) .
 

--- a/README.md
+++ b/README.md
@@ -69,6 +69,7 @@ Targets Overview (Quick Reference)
 | `make patch`        | Apply local patches (copy `debugtool` sources and replace `root.go`).                             |
 | `make build`        | Compile `istioctl` from source after cloning and applying patches.                                |
 | `make image`        | Build Docker image with the compiled binary. Optionally bundle extra files via `EXTRA_FILES_DIR`. |
+| `make image EXTRA_FILES_DIR=<file\|dir>` | Bundle additional files (single file or directory) into `/usr/local/bin/` in the image. |
 | `make switch-user`  | Re-run the build as another Linux user (requires `RUN_AS_USER=<username>`).                       |
 | `make mylab`        | Run a custom **mylab\_cli** build (requires `OWNER=<owner>`).                                     |
 | `make version`      | Print built image tag and cleanup temporary `bin/istioctl`.                                       |
@@ -90,28 +91,6 @@ make mylab OWNER=me  # Internal mylab build
 # Build a specific version
 make ISTIO_CODE_VERSION=1.13.5 OUTPUT_IMAGE_VERSION=1.13.5-custom-v1
 ```
-
-## 1a. Bundle extra files into the image (optional)
-
-Use `EXTRA_FILES_DIR` to include additional tools or files in the image at build time.
-The files are copied to `/usr/local/bin/` inside the container.
-
-`EXTRA_FILES_DIR` accepts either a **single file** or a **directory**:
-
-```bash
-# Single file
-make image EXTRA_FILES_DIR=/path/to/istio-1.29.2-linux-amd64.tar.gz
-
-# Directory (all contents are bundled)
-mkdir -p extra/
-cp /path/to/tool extra/
-make image EXTRA_FILES_DIR=extra/
-
-# Combined with mylab
-make mylab OWNER=me EXTRA_FILES_DIR=extra/
-```
-
-> Files in `bin/extra/` are automatically cleaned up by `make version` and `make clean`.
 
 ## 2. Load the image into Kind
 ```bash

--- a/README.md
+++ b/README.md
@@ -68,7 +68,7 @@ Targets Overview (Quick Reference)
 | `make clone`        | Clone or update the Istio repo at `$(BUILD_DIR)` and checkout `ISTIO_CODE_VERSION`.               |
 | `make patch`        | Apply local patches (copy `debugtool` sources and replace `root.go`).                             |
 | `make build`        | Compile `istioctl` from source after cloning and applying patches.                                |
-| `make image`        | Build Docker image with the compiled binary.                                                      |
+| `make image`        | Build Docker image with the compiled binary. Optionally bundle extra files via `EXTRA_FILES_DIR`. |
 | `make switch-user`  | Re-run the build as another Linux user (requires `RUN_AS_USER=<username>`).                       |
 | `make mylab`        | Run a custom **mylab\_cli** build (requires `OWNER=<owner>`).                                     |
 | `make version`      | Print built image tag and cleanup temporary `bin/istioctl`.                                       |
@@ -90,6 +90,28 @@ make mylab OWNER=me  # Internal mylab build
 # Build a specific version
 make ISTIO_CODE_VERSION=1.13.5 OUTPUT_IMAGE_VERSION=1.13.5-custom-v1
 ```
+
+## 1a. Bundle extra files into the image (optional)
+
+Use `EXTRA_FILES_DIR` to include additional tools or files in the image at build time.
+The files are copied to `/usr/local/bin/` inside the container.
+
+`EXTRA_FILES_DIR` accepts either a **single file** or a **directory**:
+
+```bash
+# Single file
+make image EXTRA_FILES_DIR=/path/to/istio-1.29.2-linux-amd64.tar.gz
+
+# Directory (all contents are bundled)
+mkdir -p extra/
+cp /path/to/tool extra/
+make image EXTRA_FILES_DIR=extra/
+
+# Combined with mylab
+make mylab OWNER=me EXTRA_FILES_DIR=extra/
+```
+
+> Files in `bin/extra/` are automatically cleaned up by `make version` and `make clean`.
 
 ## 2. Load the image into Kind
 ```bash
@@ -183,4 +205,5 @@ git restore .
 - For internal builds (`make mylab`), remember to set `OWNER=<your-org>`.
 - For non-root builds, use `make switch-user RUN_AS_USER=<username>`.
 - If build fails with `permission denied on /gocache`, run: `docker volume rm gocache`.
+- To include extra tools in the image, use `make image EXTRA_FILES_DIR=<file-or-dir>`. Files land in `/usr/local/bin/` inside the container.
 - `/github-flow` requires `gh` CLI login（執行 `/setup-github-ssh` 完成初始設定）with Contents / Issues / Pull requests read & write permissions.


### PR DESCRIPTION
## Summary

- Add `.gcloudignore` to fix `make mylab` Cloud Build failure — `gcloud builds submit` defaults to `.gitignore` as upload filter, which excluded `bin/istioctl` from the source context
- Add `EXTRA_FILES_DIR` variable: `make image EXTRA_FILES_DIR=extra/` stages the specified directory into `bin/extra/` before `docker build`, allowing custom tools/binaries to be bundled into the debug pod image
- Update `Dockerfile` to `COPY bin/extra/ .` so extra files land in `/usr/local/bin/`
- Update `.gitignore` to exclude `bin/extra/` from version control

Closes #76

## Test plan

- [ ] `make mylab OWNER=<owner>` succeeds (Cloud Build receives `bin/istioctl`)
- [ ] `make image` without `EXTRA_FILES_DIR` builds successfully (empty `bin/extra/` is handled)
- [ ] `make image EXTRA_FILES_DIR=extra/` copies files from `extra/` into the image
- [ ] `make version` and `make clean` clean up `bin/extra/`

🤖 Generated with [Claude Code](https://claude.com/claude-code)