### PR TITLE
sync: merge dev branch into main

### DIFF
--- a/.gcloudignore
+++ b/.gcloudignore
@@ -1,0 +1,5 @@
+# Inherit .gitignore rules, then explicitly include the compiled binaries
+# and extra files needed by the Dockerfile's COPY steps.
+#!include:.gitignore
+!bin/istioctl
+!bin/extra/

--- a/.gitignore
+++ b/.gitignore
@@ -1,1 +1,2 @@
 bin/istioctl
+bin/extra/

--- a/Dockerfile
+++ b/Dockerfile
@@ -5,6 +5,7 @@ RUN apk add --no-cache bash curl ca-certificates
 
 WORKDIR /usr/local/bin
 COPY bin/istioctl .
+COPY bin/extra/ .
 RUN chmod +x istioctl
 
 # 預設進入 bash，方便互動

--- a/Makefile
+++ b/Makefile
@@ -8,6 +8,7 @@ BUILD_DIR          ?= /tmp/build
 DOCKER_IMAGE       ?= istioctl-debug:$(OUTPUT_IMAGE_VERSION)
 RUN_AS_USER        ?=
 OWNER              ?=
+EXTRA_FILES_DIR    ?=
 
 .DEFAULT_GOAL := all
 
@@ -53,7 +54,7 @@ help:
 	@echo "  make version          Show built image and cleanup binary"
 	@echo "  make clean            Remove build artifacts"
 	@echo ""
-	@echo "Variables you can override: ISTIO_CODE_VERSION, OUTPUT_IMAGE_VERSION, BUILD_DIR, DOCKER_IMAGE, RUN_AS_USER, OWNER"
+	@echo "Variables you can override: ISTIO_CODE_VERSION, OUTPUT_IMAGE_VERSION, BUILD_DIR, DOCKER_IMAGE, RUN_AS_USER, OWNER, EXTRA_FILES_DIR"
 
 # ============================================================
 # Pre-checks
@@ -122,6 +123,18 @@ all: image version
 
 image: build
 	@echo "🐳 Building docker image: $(DOCKER_IMAGE)"
+	mkdir -p bin/extra
+	@if [ -n "$(EXTRA_FILES_DIR)" ]; then \
+	  if [ -f "$(EXTRA_FILES_DIR)" ]; then \
+	    echo "📦 Staging extra file: $(EXTRA_FILES_DIR)"; \
+	    cp "$(EXTRA_FILES_DIR)" bin/extra/; \
+	  elif [ -d "$(EXTRA_FILES_DIR)" ]; then \
+	    echo "📦 Staging extra files from dir: $(EXTRA_FILES_DIR)"; \
+	    cp -r "$(EXTRA_FILES_DIR)/." bin/extra/; \
+	  else \
+	    echo "❌ EXTRA_FILES_DIR not found: $(EXTRA_FILES_DIR)"; exit 1; \
+	  fi \
+	fi
 	docker build -t $(DOCKER_IMAGE) .
 
 switch-user:
@@ -145,8 +158,9 @@ mylab:
 # ============================================================
 version:
 	@echo "✅ Built image: $(DOCKER_IMAGE)"
-	@echo "🧹 Cleanup local bin/istioctl ..."
+	@echo "🧹 Cleanup local bin/ ..."
 	rm -f bin/istioctl
+	rm -rf bin/extra
 
 clean:
 	@echo "🧹 Cleaning up build dir and bin ..."

--- a/README.md
+++ b/README.md
@@ -68,7 +68,8 @@ Targets Overview (Quick Reference)
 | `make clone`        | Clone or update the Istio repo at `$(BUILD_DIR)` and checkout `ISTIO_CODE_VERSION`.               |
 | `make patch`        | Apply local patches (copy `debugtool` sources and replace `root.go`).                             |
 | `make build`        | Compile `istioctl` from source after cloning and applying patches.                                |
-| `make image`        | Build Docker image with the compiled binary.                                                      |
+| `make image`        | Build Docker image with the compiled binary. Optionally bundle extra files via `EXTRA_FILES_DIR`. |
+| `make image EXTRA_FILES_DIR=<file\|dir>` | Bundle additional files (single file or directory) into `/usr/local/bin/` in the image. |
 | `make switch-user`  | Re-run the build as another Linux user (requires `RUN_AS_USER=<username>`).                       |
 | `make mylab`        | Run a custom **mylab\_cli** build (requires `OWNER=<owner>`).                                     |
 | `make version`      | Print built image tag and cleanup temporary `bin/istioctl`.                                       |
@@ -183,4 +184,5 @@ git restore .
 - For internal builds (`make mylab`), remember to set `OWNER=<your-org>`.
 - For non-root builds, use `make switch-user RUN_AS_USER=<username>`.
 - If build fails with `permission denied on /gocache`, run: `docker volume rm gocache`.
+- To include extra tools in the image, use `make image EXTRA_FILES_DIR=<file-or-dir>`. Files land in `/usr/local/bin/` inside the container.
 - `/github-flow` requires `gh` CLI login（執行 `/setup-github-ssh` 完成初始設定）with Contents / Issues / Pull requests read & write permissions.


### PR DESCRIPTION
## Summary

- Add `.gcloudignore` to fix `make mylab` Cloud Build failure (bin/istioctl was excluded by .gitignore)
- Add `EXTRA_FILES_DIR` variable to bundle extra files into the Docker image at build time
- Update `Dockerfile` to `COPY bin/extra/` into `/usr/local/bin/`
- Update `.gitignore` to exclude `bin/extra/`
- Update `README.md` Targets table with `EXTRA_FILES_DIR` usage

Closes #76

🤖 Generated with [Claude Code](https://claude.com/claude-code)