### PR TITLE
fix: extract stage-extra target so mylab also stages bin/extra/

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -36,7 +36,7 @@ endif
 # ============================================================
 # Phony Targets
 # ============================================================
-.PHONY: help all check-tmp clone patch build image \
+.PHONY: help all check-tmp clone patch build stage-extra image \
         switch-user mylab version clean
 
 # ============================================================
@@ -121,8 +121,7 @@ build: clone patch
 # ============================================================
 all: image version
 
-image: build
-	@echo "🐳 Building docker image: $(DOCKER_IMAGE)"
+stage-extra:
 	mkdir -p bin/extra
 	@if [ -n "$(EXTRA_FILES_DIR)" ]; then \
 	  if [ -f "$(EXTRA_FILES_DIR)" ]; then \
@@ -135,6 +134,9 @@ image: build
 	    echo "❌ EXTRA_FILES_DIR not found: $(EXTRA_FILES_DIR)"; exit 1; \
 	  fi \
 	fi
+
+image: build stage-extra
+	@echo "🐳 Building docker image: $(DOCKER_IMAGE)"
 	docker build -t $(DOCKER_IMAGE) .
 
 switch-user:
@@ -149,7 +151,7 @@ mylab:
 	  echo "❌ OWNER not defined. Run with 'make mylab OWNER=<ownername>'"; \
 	  exit 1; \
 	fi
-	$(MAKE) build
+	$(MAKE) build stage-extra
 	@echo "🚀 Running internal build for $(OWNER)/$(DOCKER_IMAGE)"
 	/usr/local/mylab_cli/mylabbuild $(OWNER)/$(DOCKER_IMAGE)
 


### PR DESCRIPTION
## Summary

- Extract `stage-extra` target from `image` — handles `mkdir -p bin/extra` and `EXTRA_FILES_DIR` staging
- `image` now depends on `build stage-extra`
- `mylab` now calls `$(MAKE) build stage-extra` instead of just `$(MAKE) build`

## Root Cause

`make mylab` called `$(MAKE) build` directly, bypassing the `image` target where `bin/extra/` was created. Cloud Build received the source without `bin/extra/`, causing `COPY bin/extra/ .` to fail.

Closes #79

🤖 Generated with [Claude Code](https://claude.com/claude-code)